### PR TITLE
fix reader buffer

### DIFF
--- a/pkg/tools/sseclient.go
+++ b/pkg/tools/sseclient.go
@@ -33,7 +33,7 @@ func (c *SSEClient) Read() <-chan Event {
 	events := make(chan Event)
 	go func() {
 		defer close(events)
-		reader := bufio.NewReader(c.EventSource)
+		reader := bufio.NewReaderSize(c.EventSource, 128*1024)
 		var data bytes.Buffer
 
 		for {


### PR DESCRIPTION
当递交的数据过大时(测试了大概5k的中文字符)，会出现如下报错
```
SSEClient: 2024/02/21 15:10:56 Error reading from event source: buffer too small to hold message

```
把reader的缓冲区设置成128k应该够用了。